### PR TITLE
Add Elasticsearch friendly JSON formatter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -240,9 +240,9 @@ arguments:
 Both filters add an additional flag to the trace saying whether the trimming
 was applied.
 
-Note that both filters first serialise the input to a JSON string before
-applying the truncation which will make the shortened output most probably
-in invalid JSON.
+Note that the filters first serialise the input to a string before applying
+the truncation. If the length of string representation of the input is within
+the ``max_len`` limit, the input is kept untouched.
 
 An example of configuring logging to use the truncation filters:
 

--- a/nameko_tracer/filters.py
+++ b/nameko_tracer/filters.py
@@ -59,11 +59,10 @@ class TruncateRequestFilter(BaseTruncateFilter):
         call_args = utils.serialise_to_string(data[constants.REQUEST_KEY])
         length = len(call_args)
         if length > self.max_len:
-            call_args = call_args[:self.max_len]
+            data[constants.REQUEST_KEY] = call_args[:self.max_len]
             truncated = True
         else:
             truncated = False
-        data[constants.REQUEST_KEY] = call_args
         data[constants.REQUEST_TRUNCATED_KEY] = truncated
         data[constants.REQUEST_LENGTH_KEY] = length
         return data
@@ -91,11 +90,10 @@ class TruncateResponseFilter(BaseTruncateFilter):
         result = utils.serialise_to_string(data[constants.RESPONSE_KEY])
         length = len(result)
         if length > self.max_len:
-            result = result[:self.max_len]
+            data[constants.RESPONSE_KEY] = result[:self.max_len]
             truncated = True
         else:
             truncated = False
-        data[constants.RESPONSE_KEY] = result
         data[constants.RESPONSE_TRUNCATED_KEY] = truncated
         data[constants.RESPONSE_LENGTH_KEY] = length
         return data

--- a/nameko_tracer/formatters.py
+++ b/nameko_tracer/formatters.py
@@ -30,6 +30,8 @@ class ElasticisearchDocumentFormatter(JSONFormatter):
 
     def format(self, record):
         trace = getattr(record, constants.TRACE_KEY)
+        trace[constants.CONTEXT_DATA_KEY] = serialise(
+            trace[constants.CONTEXT_DATA_KEY])
         trace[constants.REQUEST_KEY] = serialise(
             trace[constants.REQUEST_KEY])
         trace[constants.RESPONSE_KEY] = serialise(

--- a/nameko_tracer/formatters.py
+++ b/nameko_tracer/formatters.py
@@ -8,8 +8,30 @@ def default(obj):
     return str(obj)
 
 
+def serialise(obj):
+    return json.dumps(obj, default=default)
+
+
 class JSONFormatter(logging.Formatter):
+    """ Format trace data as JSON string
+    """
 
     def format(self, record):
-        return json.dumps(
-            getattr(record, constants.TRACE_KEY), default=default)
+        return serialise(getattr(record, constants.TRACE_KEY))
+
+
+class ElasticisearchDocumentFormatter(JSONFormatter):
+    """ Format trace as JSON which can be fed to Elasticsearch as a document
+
+    Request and response data fields of the document are serialized as JSON
+    string before serialising the whole output.
+
+    """
+
+    def format(self, record):
+        trace = getattr(record, constants.TRACE_KEY)
+        trace[constants.REQUEST_KEY] = serialise(
+            trace[constants.REQUEST_KEY])
+        trace[constants.RESPONSE_KEY] = serialise(
+            trace[constants.RESPONSE_KEY])
+        return serialise(trace)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='nameko-tracer',
-    version='1.0.1',
+    version='1.0.2',
     description='Nameko extension logging entrypoint processing metrics',
     author='student.com',
     author_email='wearehiring@student.com',

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -29,9 +29,10 @@ def test_json_serialiser_will_deal_with_datetime(input_, expected_output):
 def test_elasticsearch_document_serialiser():
 
     trace = {
+        constants.CONTEXT_DATA_KEY: {'should': ('be', 'serialised')},
         constants.REQUEST_KEY: ('should', 'be', 'serialised'),
-        constants.RESPONSE_KEY: {'also': ('should', 'be', 'serialised')},
-        constants.CONTEXT_DATA_KEY: {'should': ['NOT', 'be', 'serialised']},
+        constants.RESPONSE_KEY: {'should': ('be', 'serialised')},
+        'some-other-key': {'should': ['NOT', 'be', 'serialised']},
     }
 
     log_record = Mock()
@@ -42,11 +43,14 @@ def test_elasticsearch_document_serialiser():
     document = json.loads(document)
 
     assert (
+        document[constants.CONTEXT_DATA_KEY] ==
+        '{"should": ["be", "serialised"]}')
+    assert (
         document[constants.REQUEST_KEY] ==
         '["should", "be", "serialised"]')
     assert (
         document[constants.RESPONSE_KEY] ==
-        '{"also": ["should", "be", "serialised"]}')
+        '{"should": ["be", "serialised"]}')
     assert (
-        document[constants.CONTEXT_DATA_KEY] ==
+        document['some-other-key'] ==
         {'should': ['NOT', 'be', 'serialised']})

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import json
 
 from mock import Mock
 import pytest
@@ -16,10 +17,36 @@ from nameko_tracer import constants, formatters
         ({None}, '"{None}"'),
     )
 )
-def test_json_serializer_will_deal_with_datetime(input_, expected_output):
+def test_json_serialiser_will_deal_with_datetime(input_, expected_output):
 
     log_record = Mock()
     setattr(log_record, constants.TRACE_KEY, input_)
 
     assert (
         formatters.JSONFormatter().format(log_record) == expected_output)
+
+
+def test_elasticsearch_document_serialiser():
+
+    trace = {
+        constants.REQUEST_KEY: ('should', 'be', 'serialised'),
+        constants.RESPONSE_KEY: {'also': ('should', 'be', 'serialised')},
+        constants.CONTEXT_DATA_KEY: {'should': ['NOT', 'be', 'serialised']},
+    }
+
+    log_record = Mock()
+    setattr(log_record, constants.TRACE_KEY, trace)
+
+    document = formatters.ElasticisearchDocumentFormatter().format(log_record)
+
+    document = json.loads(document)
+
+    assert (
+        document[constants.REQUEST_KEY] ==
+        '["should", "be", "serialised"]')
+    assert (
+        document[constants.RESPONSE_KEY] ==
+        '{"also": ["should", "be", "serialised"]}')
+    assert (
+        document[constants.CONTEXT_DATA_KEY] ==
+        {'should': ['NOT', 'be', 'serialised']})


### PR DESCRIPTION
The formatter can be useful in a setup where filebeat feeds elasticsearch directly with no logstash in the middle. With logstash the simple JSONFormatter can be used instead and the two fields can be serialised on the other side [using logstash filters](https://www.elastic.co/guide/en/logstash/current/plugins-filters-json_encode.html)