### PR TITLE
Fix python NoneType serialisation

### DIFF
--- a/nameko_tracer/utils.py
+++ b/nameko_tracer/utils.py
@@ -22,8 +22,8 @@ def serialise_to_string(value):
 
 
 def safe_for_serialisation(value):
-    no_op_types = six.string_types + six.integer_types + (float,)
-    if isinstance(value, no_op_types) or value is None:
+    no_op_types = six.string_types + six.integer_types + (float, type(None))
+    if isinstance(value, no_op_types):
         return value
     if isinstance(value, bytes):
         return value.decode('utf-8', 'ignore')

--- a/nameko_tracer/utils.py
+++ b/nameko_tracer/utils.py
@@ -23,7 +23,7 @@ def serialise_to_string(value):
 
 def safe_for_serialisation(value):
     no_op_types = six.string_types + six.integer_types + (float,)
-    if isinstance(value, no_op_types):
+    if isinstance(value, no_op_types) or value is None:
         return value
     if isinstance(value, bytes):
         return value.decode('utf-8', 'ignore')

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -138,7 +138,7 @@ class TestDefaultAdapter:
         assert data['context_data']['some-key'] == 'simple-data'
         assert (
             data['context_data']['some-other-key'] ==
-            {'a bit more': ['complex data', 1, 'None']})
+            {'a bit more': ['complex data', 1, None]})
 
     @pytest.mark.parametrize(
         'stage',
@@ -200,7 +200,7 @@ class TestDefaultAdapter:
     @pytest.mark.parametrize(
         ('result_in', 'expected_result_out'),
         (
-            (None, 'None'),
+            (None, None),
             ('spam', 'spam'),
             ({'spam': 'ham'}, {'spam': 'ham'}),
         ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ from nameko_tracer import utils
         ({'string': 'string'}, {'string': 'string'}),
         ({1}, [1]),
         (object, repr(object)),
-        (None, 'None'),
+        (None, None),
         (
             ((1, 0.5, 'string', object), [], {}, set()),
             [[1, 0.5, 'string', repr(object)], [], {}, []],


### PR DESCRIPTION
Found an issue where the tracer was sending `'None'` as a string instead of JSON `null`. This fixes it